### PR TITLE
Rename app to screen_test

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-Screenomics
+screen_test

--- a/.project
+++ b/.project
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>Screenomics</name>
-	<comment>Project ScreenomicsApp created by Buildship.</comment>
+	<name>screen_test</name>
+	<comment>Project screen_testApp created by Buildship.</comment>
 	<projects>
 	</projects>
 	<buildSpec>

--- a/app/src/main/java/com/screenomics/CaptureService.java
+++ b/app/src/main/java/com/screenomics/CaptureService.java
@@ -352,7 +352,7 @@ public class CaptureService extends Service {
         PendingIntent pendingIntent = PendingIntent.getActivity(this,0, notificationIntent, intentflags);
         /*Notification notification = new Notification.Builder(this, CHANNEL_ID)
                 .setSmallIcon(R.drawable.dna)
-                .setContentTitle("ScreenLife Capture is running!")
+                .setContentTitle("screen_test is running!")
                 .setContentText("If this notification disappears, please re-enable it from the application!")
                 .setContentIntent(pendingIntent)
                 .setOngoing(true)
@@ -361,7 +361,7 @@ public class CaptureService extends Service {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             notification = new Notification.Builder(this, CHANNEL_ID)
                     .setSmallIcon(R.drawable.dna)
-                    .setContentTitle("ScreenLife Capture is currently enabled")
+                    .setContentTitle("screen_test is currently enabled")
                     .setContentText("If this notification disappears, please re-enable it from the application.")
                     .setContentIntent(pendingIntent)
                     .build();
@@ -502,7 +502,7 @@ public class CaptureService extends Service {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
             notification = new Notification.Builder(this, CHANNEL_ID)
                     .setSmallIcon(R.drawable.ic_launcher_foreground)
-                    .setContentTitle("ScreenLife Capture is NOT Running!")
+                    .setContentTitle("screen_test is NOT Running!")
                     .setContentText("Please restart the application!")
                     .setContentIntent(pendingIntent)
                     .build();
@@ -529,7 +529,7 @@ public class CaptureService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel serviceChannel = new NotificationChannel(
                     CHANNEL_ID,
-                    "Screenomics Service Channel",
+                    "screen_test Service Channel",
                     NotificationManager.IMPORTANCE_HIGH
             );
             NotificationManager notificationManager = getSystemService(NotificationManager.class);

--- a/app/src/main/java/com/screenomics/InfoDialog.java
+++ b/app/src/main/java/com/screenomics/InfoDialog.java
@@ -12,8 +12,8 @@ public class InfoDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setTitle("ND ScreenLife Capture")
-                .setMessage("Developed by researchers from the Singapore University of Technology and Design, ScreenLife Capture is a smartphone application that captures high frequency screenshots of your smartphone use. When in use, the data is securely encrypted and sent over to the research team at Notre Dame.\n\n" +
+        builder.setTitle("screen_test")
+                .setMessage("Developed by researchers from the Singapore University of Technology and Design, screen_test is a smartphone application that captures high frequency screenshots of your smartphone use. When in use, the data is securely encrypted and sent over to the research team at Notre Dame.\n\n" +
                         "This application is meant for research purposes only, and if you are not a consenting participant of a research study conducted by University of Notre Dame researchers, please delete this application immediately.")
                 .setNeutralButton("OK", null);
         return builder.create();

--- a/app/src/main/java/com/screenomics/LocationService.java
+++ b/app/src/main/java/com/screenomics/LocationService.java
@@ -94,7 +94,7 @@ public class LocationService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel serviceChannel = new NotificationChannel(
                     LOCATION_CHANNEL_ID,
-                    "Screenomics Location Channel",
+                    "screen_test Location Channel",
                     NotificationManager.IMPORTANCE_HIGH
             );
             NotificationManager notificationManager = getSystemService(NotificationManager.class);
@@ -181,8 +181,8 @@ public class LocationService extends Service {
         PendingIntent pendingIntent = PendingIntent.getActivity(this,0, notificationIntent, intentflags);
 
         Notification notification = new NotificationCompat.Builder(this, LOCATION_CHANNEL_ID)
-                .setContentTitle("SCREENOMICS")
-                .setContentTitle("Screenomics Location Updates Running")
+                .setContentTitle("screen_test")
+                .setContentTitle("screen_test Location Updates Running")
                 .setSmallIcon(R.drawable.ic_launcher_foreground)
                 .setContentIntent(pendingIntent)
                 .build();

--- a/app/src/main/java/com/screenomics/LocationWorker.kt
+++ b/app/src/main/java/com/screenomics/LocationWorker.kt
@@ -16,7 +16,7 @@ class LocationWorker(context: Context, param: WorkerParameters) :
 
     companion object {
         // unique name for the work
-        val workName = "ScreenomicsLocationWorker"
+        val workName = "screen_test_LocationWorker"
         private const val TAG = "BackgroundLocationWork"
     }
 
@@ -35,7 +35,7 @@ class LocationWorker(context: Context, param: WorkerParameters) :
         ).addOnSuccessListener { location ->
             location?.let {
                 Log.d(
-                    "Screenomics",
+                    "screen_test",
                     "Current Location = [lat : ${location.latitude}, lng : ${location.longitude}]",
                 )
                 println("Current Location = [lat : ${location.latitude}, lng : ${location.longitude}]")

--- a/app/src/main/java/com/screenomics/MainActivity.java
+++ b/app/src/main/java/com/screenomics/MainActivity.java
@@ -344,7 +344,7 @@ public class MainActivity extends AppCompatActivity {
                         screenCaptureIntent.putExtra("screenDensity", mScreenDensity);
                         startForegroundService(screenCaptureIntent);
                         startActivity(new Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
-                        Toast.makeText(MainActivity.this, "ScreenLife Capture is running!", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(MainActivity.this, "screen_test is running!", Toast.LENGTH_SHORT).show();
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -370,7 +370,7 @@ public class MainActivity extends AppCompatActivity {
             screenCaptureIntent.putExtra("screenDensity", mScreenDensity);
             startForegroundService(screenCaptureIntent);
             startActivity(new Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
-            Toast.makeText(this, "ScreenLife Capture is running!", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "screen_test is running!", Toast.LENGTH_SHORT).show();
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/app/src/main/java/com/screenomics/UploadService.java
+++ b/app/src/main/java/com/screenomics/UploadService.java
@@ -210,7 +210,7 @@ public class UploadService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel serviceChannel = new NotificationChannel(
                     "uploading-channel",
-                    "Screenomics Service Channel",
+                    "screen_test Service Channel",
                     NotificationManager.IMPORTANCE_LOW
             );
             serviceChannel.setSound(null, null);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <resources>
-    <string name="app_name">ND ASSIST Lab ScreenLife</string>
+    <string name="app_name">screen_test</string>
     <string name="capture_state_on">CAPTURING DATA</string>
     <string name="capture_state_off">CURRENTLY NOT CAPTURING DATA</string>
-    <string name="app_creator">by ND ScreenLife Capture Team</string>
+    <string name="app_creator">by screen_test Team</string>
     <string name="username_hint">Enter your name</string>
     <string name="key_hint">Create your key</string>
     <string name="firstlaunch_submit">Submit</string>

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# ScreenLife Capture Android App
+# screen_test Android App
 
-This repo contains the Android Application used in the ScreenLife Capture study. The application allows participants to record and upload screenshots taken every X number of seconds. The general layout of the code is explained below.
+This repo contains the Android Application used in the screen_test study. The application allows participants to record and upload screenshots taken every X number of seconds. The general layout of the code is explained below.
 
 ### Features added by Univeristy of Notre Dame, Center for Research Computing
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include ':app'
-rootProject.name='Screenomics'
+rootProject.name='screen_test'


### PR DESCRIPTION
## Summary
- rename the project and app labels to `screen_test`
- update user-facing strings and notifications with the new name
- update documentation

## Testing
- `./gradlew tasks --all` *(fails: No route to host)*